### PR TITLE
Switch to async fs calls

### DIFF
--- a/pages/api/empanadas.js
+++ b/pages/api/empanadas.js
@@ -3,25 +3,26 @@ import path from 'path'
 
 const dataFile = path.join(process.cwd(), 'data', 'empanadas.json')
 
-function readData() {
+async function readData() {
   try {
-    return JSON.parse(fs.readFileSync(dataFile, 'utf8'))
+    const content = await fs.promises.readFile(dataFile, 'utf8')
+    return JSON.parse(content)
   } catch {
     return []
   }
 }
 
-function writeData(data) {
+async function writeData(data) {
   fs.mkdirSync(path.dirname(dataFile), { recursive: true })
-  fs.writeFileSync(dataFile, JSON.stringify(data, null, 2))
+  await fs.promises.writeFile(dataFile, JSON.stringify(data, null, 2))
 }
 
-export default function handler(req, res) {
+export default async function handler(req, res) {
   if (req.method === 'GET') {
-    const data = readData()
+    const data = await readData()
     res.status(200).json(data)
   } else if (req.method === 'POST') {
-    const data = readData()
+    const data = await readData()
     const empanada = req.body
     const index = data.findIndex(e => e.name === empanada.name)
     if (index !== -1) {
@@ -29,7 +30,7 @@ export default function handler(req, res) {
     } else {
       data.push(empanada)
     }
-    writeData(data)
+    await writeData(data)
     res.status(200).json({ ok: true })
   } else {
     res.status(405).end()


### PR DESCRIPTION
## Summary
- use `fs.promises` with `async` handler

## Testing
- `npm test` *(fails: missing script)*
- `npm run lint` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6847f9124fcc8323acb9b38581a4d0fc