### PR TITLE
Use async fs operations

### DIFF
--- a/app/api/empanadas/route.js
+++ b/app/api/empanadas/route.js
@@ -4,26 +4,27 @@ import { NextResponse } from 'next/server'
 
 const dataFile = path.join(process.cwd(), 'data', 'empanadas.json')
 
-function readData() {
+async function readData() {
   try {
-    return JSON.parse(fs.readFileSync(dataFile, 'utf8'))
+    const fileContents = await fs.promises.readFile(dataFile, 'utf8')
+    return JSON.parse(fileContents)
   } catch {
     return []
   }
 }
 
-function writeData(data) {
-  fs.mkdirSync(path.dirname(dataFile), { recursive: true })
-  fs.writeFileSync(dataFile, JSON.stringify(data, null, 2))
+async function writeData(data) {
+  await fs.promises.mkdir(path.dirname(dataFile), { recursive: true })
+  await fs.promises.writeFile(dataFile, JSON.stringify(data, null, 2))
 }
 
 export async function GET() {
-  const data = readData()
+  const data = await readData()
   return NextResponse.json(data)
 }
 
 export async function POST(request) {
-  const data = readData()
+  const data = await readData()
   const empanada = await request.json()
   const index = data.findIndex(e => e.name === empanada.name)
   if (index !== -1) {
@@ -31,6 +32,6 @@ export async function POST(request) {
   } else {
     data.push(empanada)
   }
-  writeData(data)
+  await writeData(data)
   return NextResponse.json({ ok: true })
 }


### PR DESCRIPTION
## Summary
- rely on `fs.promises` for reading and writing JSON data
- make the API route handler await the new async functions

## Testing
- `npm run build` *(fails: `next` not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6847fbebafb08323b26e08e73547a108