### PR TITLE
Add editable concept names and new item rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,6 @@ Proyecto de ejemplo en Next.js y TypeScript para calcular los costes de una empa
    ```
 3. Abre [http://localhost:3000](http://localhost:3000) en tu navegador.
 
-En la interfaz se pueden editar individualmente los costes con el botón **Editar** y guardarlos con **Guardar**. Puedes asignar un nombre a la configuración actual y almacenarla usando **Guardar empanada**.
+En la interfaz se pueden editar individualmente los costes y también el nombre de cada concepto con el botón **Editar**. Además es posible añadir nuevos conceptos en cada bloque de categoría. Puedes asignar un nombre a la configuración actual y almacenarla usando **Guardar empanada**.
 
 Las empanadas guardadas se muestran en una lista desplegable desde donde se pueden precargar para realizar ajustes y, tras pulsar **Obtener gastos y beneficios**, consultar los totales (IVA incluido) y el beneficio según el margen indicado.


### PR DESCRIPTION
## Summary
- allow editing concept names in each table row
- add per-category row to create new concept entries
- document the new features in README

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68480c82fb948323b6419937538e238e