### PR TITLE
Add saved empanadas page with navbar links

### DIFF
--- a/app/calculadora/page.tsx
+++ b/app/calculadora/page.tsx
@@ -1,5 +1,6 @@
 "use client"
 import { useState, useEffect } from 'react'
+import { useSearchParams } from 'next/navigation'
 
 interface CostItem {
   id: string
@@ -61,10 +62,22 @@ export default function Home() {
     }
   }
 
+  const searchParams = useSearchParams()
+
   useEffect(() => {
     fetch('/api/empanadas')
       .then(res => res.json())
-      .then(setSaved)
+      .then(list => {
+        setSaved(list)
+        const nameParam = searchParams.get('emp')
+        if (nameParam) {
+          const emp = list.find(e => e.name === nameParam)
+          if (emp) {
+            loadEmpanada(emp)
+            setName(emp.name)
+          }
+        }
+      })
       .catch(() => {})
   }, [])
 

--- a/app/empanadas/page.tsx
+++ b/app/empanadas/page.tsx
@@ -1,0 +1,43 @@
+"use client"
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+
+interface Empanada {
+  name: string
+}
+
+export default function EmpanadasPage() {
+  const [list, setList] = useState<Empanada[]>([])
+  const router = useRouter()
+
+  useEffect(() => {
+    fetch('/api/empanadas')
+      .then(res => res.json())
+      .then(setList)
+      .catch(() => {})
+  }, [])
+
+  const openEmpanada = (name: string) => {
+    if (confirm('¿Abrir calculadora con esta empanada?')) {
+      router.push(`/calculadora?emp=${encodeURIComponent(name)}`)
+    }
+  }
+
+  return (
+    <div className="p-6 mt-6 max-w-md mx-auto bg-white rounded-lg shadow-lg">
+      <h1 className="text-xl font-bold mb-4">Empanadas guardadas</h1>
+      <ul className="divide-y">
+        {list.map(emp => (
+          <li
+            key={emp.name}
+            className="py-2 cursor-pointer text-blue-600 hover:underline"
+            onClick={() => openEmpanada(emp.name)}
+          >
+            {emp.name}
+          </li>
+        ))}
+        {list.length === 0 && <li>No hay empanadas guardadas</li>}
+      </ul>
+    </div>
+  )
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,8 +8,14 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         <script src="https://cdn.tailwindcss.com"></script>
       </head>
       <body className="bg-gradient-to-br from-green-50 to-green-100 text-gray-900 flex flex-col min-h-screen">
-        <header className="bg-green-600 text-white py-6 shadow-md text-center text-lg md:text-2xl font-bold">
-          O pan de San Antonio
+        <header className="bg-green-600 text-white py-4 shadow-md">
+          <div className="container mx-auto flex justify-between items-center px-4">
+            <h1 className="text-lg md:text-2xl font-bold">O pan de San Antonio</h1>
+            <nav className="text-sm md:text-base">
+              <a href="/" className="mr-4 hover:underline">Cerrar sesión</a>
+              <a href="/empanadas" className="hover:underline">Ver empanadas guardadas</a>
+            </nav>
+          </div>
         </header>
         <main className="flex-grow">
           {children}


### PR DESCRIPTION
## Summary
- add navigation links in the site header
- create `/empanadas` page to list saved empanadas and open the calculator with a query param
- allow the calculator to load an empanada specified via query string

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module 'next/server' etc.)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684818570b6483239548569bf99afa6c