### PR TITLE
Add load confirmation toast

### DIFF
--- a/app/calculadora/page.tsx
+++ b/app/calculadora/page.tsx
@@ -140,6 +140,7 @@ export default function Home() {
     setCosts(emp.costs.map(c => ({ ...c, isEditing: false })))
     setMargin(emp.margin)
     setShowTotals(false)
+    toast.success('Empanada cargada', { style: { background: '#16a34a', color: '#fff' } })
   }
 
   const total = costs.reduce((sum, item) => sum + (item.cost || 0), 0)


### PR DESCRIPTION
## Summary
- show a toast when an empanada is loaded

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684841d4c69c83239646dcd2cd315176