### PR TITLE
Add delete function for empanadas

### DIFF
--- a/app/api/empanadas/route.ts
+++ b/app/api/empanadas/route.ts
@@ -31,3 +31,26 @@ export async function POST(request: Request) {
   )
   return NextResponse.json({ ok: true })
 }
+
+export async function DELETE(request: Request) {
+  await connectDB()
+
+  const { searchParams } = new URL(request.url)
+  let name = searchParams.get('name')
+
+  if (!name) {
+    try {
+      const body = await request.json()
+      name = body?.name
+    } catch {
+      // ignore json parse error
+    }
+  }
+
+  if (!name) {
+    return NextResponse.json({ error: 'Name required' }, { status: 400 })
+  }
+
+  await Empanada.deleteOne({ name })
+  return NextResponse.json({ ok: true })
+}

--- a/app/empanadas/page.tsx
+++ b/app/empanadas/page.tsx
@@ -1,6 +1,7 @@
 "use client"
 import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
+import { toast } from 'react-toastify'
 
 interface Empanada {
   name: string
@@ -10,11 +11,13 @@ export default function EmpanadasPage() {
   const [list, setList] = useState<Empanada[]>([])
   const router = useRouter()
 
+  const fetchList = async () => {
+    const list = await fetch('/api/empanadas').then(res => res.json())
+    setList(list)
+  }
+
   useEffect(() => {
-    fetch('/api/empanadas')
-      .then(res => res.json())
-      .then(setList)
-      .catch(() => {})
+    fetchList().catch(() => {})
   }, [])
 
   const openEmpanada = (name: string) => {
@@ -23,17 +26,37 @@ export default function EmpanadasPage() {
     }
   }
 
+  const deleteEmpanada = async (name: string) => {
+    if (!confirm('¿Eliminar empanada?')) return
+    try {
+      await fetch('/api/empanadas?name=' + encodeURIComponent(name), {
+        method: 'DELETE'
+      })
+      await fetchList()
+      toast.success('Empanada eliminada', { style: { background: '#16a34a', color: '#fff' } })
+    } catch {
+      toast.error('Error al eliminar', { style: { background: '#dc2626', color: '#fff' } })
+    }
+  }
+
   return (
     <div className="p-6 mt-6 max-w-md mx-auto bg-white rounded-lg shadow-lg">
       <h1 className="text-xl font-bold mb-4">Empanadas guardadas</h1>
       <ul className="divide-y">
         {list.map(emp => (
-          <li
-            key={emp.name}
-            className="py-2 cursor-pointer text-blue-600 hover:underline"
-            onClick={() => openEmpanada(emp.name)}
-          >
-            {emp.name}
+          <li key={emp.name} className="py-2 flex justify-between items-center">
+            <span
+              className="cursor-pointer text-blue-600 hover:underline"
+              onClick={() => openEmpanada(emp.name)}
+            >
+              {emp.name}
+            </span>
+            <button
+              className="text-red-600 ml-2 hover:underline"
+              onClick={() => deleteEmpanada(emp.name)}
+            >
+              Eliminar
+            </button>
           </li>
         ))}
         {list.length === 0 && <li>No hay empanadas guardadas</li>}


### PR DESCRIPTION
## Summary
- allow deleting empanadas via DELETE handler in API
- show delete buttons on empanada list page
- refresh list and show toast messages after deletion

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684842b35fa48323922bfbf9308d33a9