### PR TITLE
Add Tailwind CDN script in app layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,19 @@ Proyecto de ejemplo en Next.js para calcular los costes de una empanada de carne
 En la interfaz se pueden editar individualmente los costes con el botón **Editar** y guardarlos con **Guardar**. Puedes asignar un nombre a la configuración actual y almacenarla usando **Guardar empanada**.
 
 Las empanadas guardadas se muestran en una lista desplegable desde donde se pueden precargar para realizar ajustes y, tras pulsar **Obtener gastos y beneficios**, consultar los totales (IVA incluido) y el beneficio según el margen indicado.
+
+## Uso de Tailwind CSS
+
+Este proyecto utiliza la CDN de Tailwind de forma predeterminada, tal como se incluye en `app/layout.js`.
+
+Si prefieres un flujo de trabajo con Tailwind compilado, instala las dependencias necesarias y genera la configuraci\u00f3n:
+
+```bash
+npm install -D tailwindcss postcss autoprefixer
+npx tailwindcss init -p
+```
+
+A continuaci\u00f3n elimina la etiqueta `<script>` de Tailwind de `app/layout.js` y en su lugar importa el CSS generado por Tailwind.
+
+El comando `npm run build` se encargar\u00e1 de procesar los estilos cada vez que construyas el proyecto.
+

--- a/app/layout.js
+++ b/app/layout.js
@@ -1,0 +1,15 @@
+'use client'
+
+import Head from 'next/head'
+import '../styles/globals.css'
+
+export default function RootLayout({ children }) {
+  return (
+    <html lang="es">
+      <Head>
+        <script src="https://cdn.tailwindcss.com"></script>
+      </Head>
+      <body className="bg-gray-100">{children}</body>
+    </html>
+  )
+}


### PR DESCRIPTION
## Summary
- include Tailwind CDN script inside `app/layout.js`
- document how to switch to a compiled Tailwind setup in README

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847f913fb34832382510b5a3d9b87da