### PR TITLE
Add JWT auth with middleware

### DIFF
--- a/app/api/logout/route.ts
+++ b/app/api/logout/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server'
+
+export async function POST() {
+  const res = NextResponse.json({ ok: true })
+  res.cookies.set({
+    name: 'token',
+    value: '',
+    httpOnly: true,
+    path: '/',
+    expires: new Date(0),
+  })
+  return res
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,6 +13,7 @@ export default function Login() {
     const res = await fetch('/api/login', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
       body: JSON.stringify({ username, password })
     })
     if (res.ok) {

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,17 +1,23 @@
 'use client'
 import Link from 'next/link'
-import { usePathname } from 'next/navigation'
+import { usePathname, useRouter } from 'next/navigation'
 
 export default function Header() {
   const pathname = usePathname()
+  const router = useRouter()
   const inside = pathname !== '/'
+
+  const logout = async () => {
+    await fetch('/api/logout', { method: 'POST', credentials: 'include' })
+    router.push('/')
+  }
   return (
     <header className="bg-green-600 text-white py-4 shadow-md">
       <div className="container mx-auto flex justify-between items-center px-4">
         <h1 className="text-lg md:text-2xl font-bold">O pan de San Antonio</h1>
         {inside && (
           <nav className="text-sm md:text-base">
-            <Link href="/" className="mr-4 hover:underline">Cerrar sesión</Link>
+            <button onClick={logout} className="mr-4 hover:underline">Cerrar sesión</button>
             <Link href="/empanadas" className="mr-4 hover:underline">Ver empanadas guardadas</Link>
             <Link href="/registro" className="hover:underline">Registro</Link>
           </nav>

--- a/lib/jwt.ts
+++ b/lib/jwt.ts
@@ -1,0 +1,26 @@
+import crypto from 'crypto'
+
+function base64url(buffer: Buffer): string {
+  return buffer.toString('base64').replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_')
+}
+
+export function sign(payload: object, secret: string): string {
+  const header = { alg: 'HS256', typ: 'JWT' }
+  const headerEncoded = base64url(Buffer.from(JSON.stringify(header)))
+  const payloadEncoded = base64url(Buffer.from(JSON.stringify(payload)))
+  const data = `${headerEncoded}.${payloadEncoded}`
+  const signature = crypto.createHmac('sha256', secret).update(data).digest()
+  const signatureEncoded = base64url(signature)
+  return `${data}.${signatureEncoded}`
+}
+
+export function verify(token: string, secret: string): any {
+  const parts = token.split('.')
+  if (parts.length !== 3) throw new Error('Invalid token')
+  const [headerEncoded, payloadEncoded, signature] = parts
+  const data = `${headerEncoded}.${payloadEncoded}`
+  const expected = base64url(crypto.createHmac('sha256', secret).update(data).digest())
+  if (signature !== expected) throw new Error('Invalid signature')
+  const payloadJson = Buffer.from(payloadEncoded, 'base64').toString()
+  return JSON.parse(payloadJson)
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verify } from './lib/jwt'
+
+const secret = process.env.JWT_SECRET || 'secret'
+
+export function middleware(request: NextRequest) {
+  const token = request.cookies.get('token')?.value
+  if (!token) {
+    return NextResponse.redirect(new URL('/', request.url))
+  }
+  try {
+    verify(token, secret)
+    return NextResponse.next()
+  } catch {
+    const res = NextResponse.redirect(new URL('/', request.url))
+    res.cookies.delete('token')
+    return res
+  }
+}
+
+export const config = {
+  matcher: ['/calculadora/:path*', '/empanadas/:path*'],
+}


### PR DESCRIPTION
## Summary
- issue JWT cookie on login
- add logout route and button
- create authentication middleware
- handle credentials on login fetch
- implement basic JWT utilities

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848446528e08323a383ffdb09d043e1