### PR TITLE
Add calculator link and active route highlighting in header

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -7,6 +7,8 @@ export default function Header() {
   const router = useRouter()
   const inside = pathname !== '/'
 
+  const isActive = (path: string) => pathname === path
+
   const logout = async () => {
     await fetch('/api/logout', { method: 'POST', credentials: 'include' })
     router.push('/')
@@ -18,8 +20,24 @@ export default function Header() {
         {inside && (
           <nav className="text-sm md:text-base">
             <button onClick={logout} className="mr-4 hover:underline">Cerrar sesión</button>
-            <Link href="/empanadas" className="mr-4 hover:underline">Ver empanadas guardadas</Link>
-            <Link href="/registro" className="hover:underline">Registro</Link>
+            <Link
+              href="/calculadora"
+              className={`mr-4 hover:underline ${isActive('/calculadora') ? 'text-yellow-200 font-bold' : ''}`}
+            >
+              Calculadora
+            </Link>
+            <Link
+              href="/empanadas"
+              className={`mr-4 hover:underline ${isActive('/empanadas') ? 'text-yellow-200 font-bold' : ''}`}
+            >
+              Ver empanadas guardadas
+            </Link>
+            <Link
+              href="/registro"
+              className={`hover:underline ${isActive('/registro') ? 'text-yellow-200 font-bold' : ''}`}
+            >
+              Registro
+            </Link>
           </nav>
         )}
       </div>


### PR DESCRIPTION
## Summary
- add `isActive` helper using `usePathname`
- highlight active navigation links
- include new `Calculadora` link in header

## Testing
- `npm run build` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6848487076588323ad924dc6cd0d2d38