### PR TITLE
Fix JWT verification

### DIFF
--- a/lib/jwt.ts
+++ b/lib/jwt.ts
@@ -4,6 +4,13 @@ function base64url(buffer: Buffer): string {
   return buffer.toString('base64').replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_')
 }
 
+function base64urlDecode(str: string): Buffer {
+  const base64 = str.replace(/-/g, '+').replace(/_/g, '/');
+  const pad = base64.length % 4;
+  const padded = base64 + (pad === 2 ? '==' : pad === 3 ? '=' : pad === 1 ? '===' : '');
+  return Buffer.from(padded, 'base64');
+}
+
 export function sign(payload: object, secret: string): string {
   const header = { alg: 'HS256', typ: 'JWT' }
   const headerEncoded = base64url(Buffer.from(JSON.stringify(header)))
@@ -21,6 +28,6 @@ export function verify(token: string, secret: string): any {
   const data = `${headerEncoded}.${payloadEncoded}`
   const expected = base64url(crypto.createHmac('sha256', secret).update(data).digest())
   if (signature !== expected) throw new Error('Invalid signature')
-  const payloadJson = Buffer.from(payloadEncoded, 'base64').toString()
+  const payloadJson = base64urlDecode(payloadEncoded).toString()
   return JSON.parse(payloadJson)
 }


### PR DESCRIPTION
## Summary
- support base64url decoding in JWT helper

## Testing
- `npm run build` *(fails: `next: not found`)*
- `npm install` *(fails: 403 Forbidden to registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68485a0aa6d88323a2195b9340ff705b