### PR TITLE
Fix token validation by exposing secret to middleware

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  env: {
+    JWT_SECRET: process.env.JWT_SECRET,
+  },
+};


### PR DESCRIPTION
## Summary
- enable middleware to read JWT_SECRET with next.config.js

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68485d0a3828832392a432e47e8ee373