### PR TITLE
Add unauthorized modal

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,12 +1,21 @@
 "use client"
-import { useState } from 'react'
-import { useRouter } from 'next/navigation'
+import { useState, useEffect } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
 import { toast } from 'react-toastify'
 
 export default function Login() {
   const [username, setUsername] = useState('')
   const [password, setPassword] = useState('')
   const router = useRouter()
+  const searchParams = useSearchParams()
+  const [showUnauthorized, setShowUnauthorized] = useState(false)
+
+  useEffect(() => {
+    if (searchParams.get('unauthorized')) {
+      setShowUnauthorized(true)
+      router.replace('/')
+    }
+  }, [searchParams, router])
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -25,7 +34,7 @@ export default function Login() {
   }
 
   return (
-    <div className="p-6 mt-6 max-w-sm mx-auto bg-white rounded-lg shadow-lg">
+    <div className="p-6 mt-6 max-w-sm mx-auto bg-white rounded-lg shadow-lg relative">
       <h1 className="text-xl font-bold mb-4 text-center">Login</h1>
       <form onSubmit={handleSubmit} className="flex flex-col gap-2">
         <input
@@ -46,6 +55,20 @@ export default function Login() {
           Entrar
         </button>
       </form>
+
+      {showUnauthorized && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+          <div className="bg-white p-4 rounded shadow-md text-center">
+            <p className="mb-4">No tienes autorización para acceder.</p>
+            <button
+              onClick={() => setShowUnauthorized(false)}
+              className="bg-green-600 text-white px-4 py-2 rounded"
+            >
+              Cerrar
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -4,7 +4,9 @@ export function middleware(request: NextRequest) {
   const token = request.cookies.get('token')?.value
   const expected = process.env.STATIC_TOKEN || ''
   if (!token || token !== expected) {
-    const res = NextResponse.redirect(new URL('/', request.url))
+    const url = new URL('/', request.url)
+    url.searchParams.set('unauthorized', '1')
+    const res = NextResponse.redirect(url)
     res.cookies.delete('token')
     return res
   }


### PR DESCRIPTION
## Summary
- show unauthorized modal on login page
- redirect with unauthorized query param in middleware

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848661d3d908323bacf9a381b483490