### PR TITLE
Add Jest testing setup

### DIFF
--- a/__tests__/api/productos.test.ts
+++ b/__tests__/api/productos.test.ts
@@ -1,0 +1,43 @@
+import { GET, POST, DELETE } from '../../app/api/productos/route'
+import Product from '../../models/Product'
+import connectDB from '../../lib/mongoose'
+
+jest.mock('../../lib/mongoose')
+jest.mock('../../models/Product', () => ({
+  find: jest.fn(),
+  updateOne: jest.fn(),
+  deleteOne: jest.fn()
+}))
+
+const mockedProduct = Product as jest.Mocked<typeof Product>
+
+describe('product API', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('GET returns list of products', async () => {
+    mockedProduct.find.mockResolvedValue([{ name: 'Test' }])
+    const res = await GET()
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(data).toEqual([{ name: 'Test' }])
+  })
+
+  it('POST upserts product', async () => {
+    const req = new Request('http://localhost/api/productos', {
+      method: 'POST',
+      body: JSON.stringify({ name: 'New', unitType: 'unidad', price: 1, vat: 0 })
+    })
+    const res = await POST(req)
+    expect(mockedProduct.updateOne).toHaveBeenCalled()
+    expect(res.status).toBe(200)
+  })
+
+  it('DELETE removes product', async () => {
+    const req = new Request('http://localhost/api/productos?name=Del', { method: 'DELETE' })
+    const res = await DELETE(req)
+    expect(mockedProduct.deleteOne).toHaveBeenCalledWith({ name: 'Del' })
+    expect(res.status).toBe(200)
+  })
+})

--- a/__tests__/components/Header.test.tsx
+++ b/__tests__/components/Header.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from '@testing-library/react'
+import Header from '../../components/Header'
+
+jest.mock('next/navigation', () => ({
+  usePathname: () => '/',
+  useRouter: () => ({ push: jest.fn() })
+}))
+
+describe('Header component', () => {
+  it('renders the site title', () => {
+    render(<Header />)
+    expect(screen.getByText('O pan de San Antonio')).toBeInTheDocument()
+  })
+})

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  moduleNameMapper: {
+    '\\.(css|less|scss|sass)$': 'identity-obj-proxy'
+  },
+  globals: {
+    'ts-jest': {
+      tsconfig: 'tsconfig.jest.json'
+    }
+  }
+};

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "test": "jest"
   },
   "dependencies": {
     "next": "14.0.0",
@@ -18,6 +19,12 @@
     "typescript": "^5.2.2",
     "@types/react": "^18.2.24",
     "@types/react-dom": "^18.2.8",
-    "@types/node": "^20.4.2"
+    "@types/node": "^20.4.2",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "@types/jest": "^29.5.10",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^5.17.0",
+    "identity-obj-proxy": "^3.0.0"
   }
 }

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "jsx": "react-jsx"
+  }
+}


### PR DESCRIPTION
## Summary
- setup Jest and React Testing Library
- configure ts-jest and create custom tsconfig for tests
- add API tests for products route
- add rendering test for Header component

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848702eb3e48323bd22dc9844241bf2