### PR TITLE
Add category and unit enums

### DIFF
--- a/app/api/productos/route.ts
+++ b/app/api/productos/route.ts
@@ -1,13 +1,13 @@
 import { NextResponse } from 'next/server'
 import connectDB from '../../../lib/mongoose'
-import Product from '../../../models/Product'
+import Product, { UnitType, Category } from '../../../models/Product'
 
 interface ProductPayload {
   name: string
-  unitType: 'kilo' | 'envase' | 'unidad'
+  unitType: UnitType
   price: number
   vat: number
-  category?: string
+  category?: Category
 }
 
 export async function GET() {
@@ -18,6 +18,12 @@ export async function GET() {
 
 export async function POST(request: Request) {
   const product = (await request.json()) as ProductPayload
+  if (!Object.values(UnitType).includes(product.unitType)) {
+    return NextResponse.json({ error: 'Invalid unit type' }, { status: 400 })
+  }
+  if (product.category && !Object.values(Category).includes(product.category)) {
+    return NextResponse.json({ error: 'Invalid category' }, { status: 400 })
+  }
   await connectDB()
   await Product.updateOne({ name: product.name }, { $set: product }, { upsert: true })
   return NextResponse.json({ ok: true })

--- a/app/calculadora/page.tsx
+++ b/app/calculadora/page.tsx
@@ -18,18 +18,27 @@ interface Empanada {
   margin: number
 }
 
+type Category =
+  | 'Relleno'
+  | 'Masa'
+  | 'Horneado'
+  | 'Envasado y Etiquetado'
+  | 'Mano de obra'
+
+type UnitType = 'kilo' | 'envase' | 'unidad' | 'metro'
+
 interface Product {
   name: string
-  unitType: 'kilo' | 'envase' | 'unidad'
+  unitType: UnitType
   price: number
   vat: number
-  category?: string
+  category?: Category
 }
 
 interface NewEntry {
   productName?: string
   name: string
-  unitType: 'kilo' | 'envase' | 'unidad'
+  unitType: UnitType
   price: number
   vat: number
   quantity: number
@@ -407,6 +416,7 @@ export default function Home() {
                         <option value="kilo">kilo</option>
                         <option value="envase">envase</option>
                         <option value="unidad">unidad</option>
+                        <option value="metro">metro</option>
                       </select>
                     </>
                   )}

--- a/app/productos/page.tsx
+++ b/app/productos/page.tsx
@@ -2,12 +2,21 @@
 import { useEffect, useState } from 'react'
 import { toast } from 'react-toastify'
 
+type Category =
+  | 'Relleno'
+  | 'Masa'
+  | 'Horneado'
+  | 'Envasado y Etiquetado'
+  | 'Mano de obra'
+
+type UnitType = 'kilo' | 'envase' | 'unidad' | 'metro'
+
 interface Product {
   name: string
-  unitType: 'kilo' | 'envase' | 'unidad'
+  unitType: UnitType
   price: number
   vat: number
-  category?: string
+  category?: Category
 }
 
 const emptyForm: Product = { name: '', unitType: 'kilo', price: 0, vat: 21 }
@@ -73,6 +82,7 @@ export default function ProductosPage() {
           <option value="kilo">kilo</option>
           <option value="envase">envase</option>
           <option value="unidad">unidad</option>
+          <option value="metro">metro</option>
         </select>
         <input
           type="number"

--- a/models/Product.ts
+++ b/models/Product.ts
@@ -1,23 +1,38 @@
 import mongoose, { Schema, Document, Model } from 'mongoose'
 
+export enum Category {
+  Relleno = 'Relleno',
+  Masa = 'Masa',
+  Horneado = 'Horneado',
+  EnvasadoEtiquetado = 'Envasado y Etiquetado',
+  ManoDeObra = 'Mano de obra',
+}
+
+export enum UnitType {
+  Kilo = 'kilo',
+  Envase = 'envase',
+  Unidad = 'unidad',
+  Metro = 'metro',
+}
+
 export interface IProduct extends Document {
   name: string
-  unitType: 'kilo' | 'envase' | 'unidad'
+  unitType: UnitType
   price: number
   vat: number
-  category?: string
+  category?: Category
 }
 
 const ProductSchema = new Schema<IProduct>({
   name: { type: String, required: true, unique: true },
   unitType: {
     type: String,
-    enum: ['kilo', 'envase', 'unidad'],
+    enum: Object.values(UnitType),
     required: true,
   },
   price: { type: Number, required: true },
   vat: { type: Number, required: true },
-  category: { type: String },
+  category: { type: String, enum: Object.values(Category) },
 })
 
 const Product =


### PR DESCRIPTION
## Summary
- add Category and UnitType enums to Mongoose model
- validate against enums in product API
- extend product manager and calculator pages with new enum types
- support `metro` units in dropdowns

## Testing
- `npm test` *(fails: jest not found)*
- `npx tsc -p tsconfig.json` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6848763763b08323849a14c8707d3edc