### PR TITLE
Add product edit navigation

### DIFF
--- a/app/calculadora/page.tsx
+++ b/app/calculadora/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 import { useState, useEffect } from 'react'
-import { useSearchParams } from 'next/navigation'
+import { useSearchParams, useRouter } from 'next/navigation'
 import { toast } from 'react-toastify'
 
 interface CostItem {
@@ -96,6 +96,7 @@ export default function Home() {
   }
 
   const searchParams = useSearchParams()
+  const router = useRouter()
 
   useEffect(() => {
     fetch('/api/empanadas')
@@ -363,7 +364,16 @@ export default function Home() {
                     ) : (
                       <>
                         {item.vat}
-                        <button onClick={() => toggleEdit(item.id)} className="ml-2 bg-blue-600 text-white px-2 py-1 rounded">Editar</button>
+                        <button
+                          onClick={() =>
+                            router.push(
+                              `/productos?edit=${encodeURIComponent(item.label)}`
+                            )
+                          }
+                          className="ml-2 bg-blue-600 text-white px-2 py-1 rounded"
+                        >
+                          Editar
+                        </button>
                         <button onClick={() => deleteItem(item.id)} className="ml-2 bg-red-600 text-white px-2 py-1 rounded">Borrar</button>
                       </>
                     )}

--- a/app/productos/page.tsx
+++ b/app/productos/page.tsx
@@ -1,5 +1,6 @@
 "use client"
 import { useEffect, useState } from 'react'
+import { useSearchParams } from 'next/navigation'
 import { toast } from 'react-toastify'
 
 type Category =
@@ -38,6 +39,7 @@ const emptyForm: Product = {
 export default function ProductosPage() {
   const [list, setList] = useState<Product[]>([])
   const [form, setForm] = useState<Product>(emptyForm)
+  const searchParams = useSearchParams()
 
   const fetchList = async () => {
     const list = await fetch('/api/productos').then(res => res.json())
@@ -47,6 +49,16 @@ export default function ProductosPage() {
   useEffect(() => {
     fetchList().catch(() => {})
   }, [])
+
+  useEffect(() => {
+    const nameParam = searchParams.get('edit')
+    if (nameParam && list.length) {
+      const prod = list.find(p => p.name === nameParam)
+      if (prod) {
+        setForm(prod)
+      }
+    }
+  }, [searchParams, list])
 
   const saveProduct = async () => {
     if (!form.name) return


### PR DESCRIPTION
## Summary
- link cost table edit buttons to the product page
- preload a product in the form when `edit` query is present

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68487c8b7c5c83239d3edefdecd1a148