### PR TITLE
Add unsaved changes warnings

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,4 +1,5 @@
 'use client'
+import React from 'react'
 import Link from 'next/link'
 import { usePathname, useRouter } from 'next/navigation'
 
@@ -6,6 +7,13 @@ export default function Header() {
   const pathname = usePathname()
   const router = useRouter()
   const inside = pathname !== '/'
+
+  const handleNav = (href: string, e: React.MouseEvent<HTMLAnchorElement>) => {
+    if (pathname === '/calculadora' && (window as any).calculatorDirty) {
+      e.preventDefault()
+      window.dispatchEvent(new CustomEvent('calculator:navigate', { detail: { href } }))
+    }
+  }
 
   const isActive = (path: string) => pathname === path
 
@@ -22,24 +30,28 @@ export default function Header() {
             <button onClick={logout} className="mr-4 hover:underline">Cerrar sesión</button>
             <Link
               href="/calculadora"
+              onClick={e => handleNav('/calculadora', e)}
               className={`mr-4 hover:underline ${isActive('/calculadora') ? 'text-yellow-200 font-bold' : ''}`}
             >
               Calculadora
             </Link>
             <Link
               href="/empanadas"
+              onClick={e => handleNav('/empanadas', e)}
               className={`mr-4 hover:underline ${isActive('/empanadas') ? 'text-yellow-200 font-bold' : ''}`}
             >
               Ver empanadas guardadas
             </Link>
             <Link
               href="/productos"
+              onClick={e => handleNav('/productos', e)}
               className={`mr-4 hover:underline ${isActive('/productos') ? 'text-yellow-200 font-bold' : ''}`}
             >
               Productos
             </Link>
             <Link
               href="/registro"
+              onClick={e => handleNav('/registro', e)}
               className={`hover:underline ${isActive('/registro') ? 'text-yellow-200 font-bold' : ''}`}
             >
               Registro


### PR DESCRIPTION
## Summary
- warn when leaving calculator page with unsaved changes
- show modal when navigating away or loading another empanada
- allow saving current state as new empanada
- intercept header navigation when calculator is dirty

## Testing
- `npm test` *(fails: jest not found)*
- `npx tsc -p tsconfig.json` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_684a9c096ccc8323a4c7273073d89768