### PR TITLE
Implement dynamic product categories

### DIFF
--- a/app/api/productos/route.ts
+++ b/app/api/productos/route.ts
@@ -1,13 +1,13 @@
 import { NextResponse } from 'next/server'
 import connectDB from '../../../lib/mongoose'
-import Product, { UnitType, Category } from '../../../models/Product'
+import Product, { UnitType } from '../../../models/Product'
 
 interface ProductPayload {
   name: string
   unitType: UnitType
   price: number
   vat: number
-  category?: Category
+  category?: string
 }
 
 export async function GET() {
@@ -20,9 +20,6 @@ export async function POST(request: Request) {
   const product = (await request.json()) as ProductPayload
   if (!Object.values(UnitType).includes(product.unitType)) {
     return NextResponse.json({ error: 'Invalid unit type' }, { status: 400 })
-  }
-  if (product.category && !Object.values(Category).includes(product.category)) {
-    return NextResponse.json({ error: 'Invalid category' }, { status: 400 })
   }
   await connectDB()
   await Product.updateOne({ name: product.name }, { $set: product }, { upsert: true })

--- a/components/ProductEditModal.tsx
+++ b/components/ProductEditModal.tsx
@@ -1,13 +1,9 @@
 'use client'
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { toast } from 'react-toastify'
+import { getStoredCategories } from '../lib/categories'
 
-export type Category =
-  | 'Relleno'
-  | 'Masa'
-  | 'Horneado'
-  | 'Envasado y Etiquetado'
-  | 'Mano de obra'
+export type Category = string
 
 export type UnitType = 'kilo' | 'envase' | 'unidad' | 'metro'
 
@@ -19,22 +15,22 @@ export interface Product {
   category?: Category
 }
 
-const categories: Category[] = [
-  'Relleno',
-  'Masa',
-  'Horneado',
-  'Envasado y Etiquetado',
-  'Mano de obra',
-]
-
 interface Props {
   product: Product
   onClose: () => void
   onSaved: (updated: Product) => void
+  categories?: string[]
 }
 
-export default function ProductEditModal({ product, onClose, onSaved }: Props) {
+export default function ProductEditModal({ product, onClose, onSaved, categories: propCategories }: Props) {
   const [form, setForm] = useState<Product>(product)
+  const [categories, setCategories] = useState<string[]>(propCategories || [])
+
+  useEffect(() => {
+    if (!propCategories) {
+      setCategories(getStoredCategories())
+    }
+  }, [propCategories])
 
   const saveProduct = async () => {
     if (!form.name) return

--- a/lib/categories.ts
+++ b/lib/categories.ts
@@ -1,0 +1,18 @@
+export const DEFAULT_CATEGORIES = [
+  'Relleno',
+  'Masa',
+  'Horneado',
+  'Envasado y Etiquetado',
+  'Mano de obra',
+]
+
+export const getStoredCategories = (): string[] => {
+  if (typeof window === 'undefined') return DEFAULT_CATEGORIES
+  const stored = localStorage.getItem('categories')
+  return stored ? JSON.parse(stored) : DEFAULT_CATEGORIES
+}
+
+export const saveCategories = (cats: string[]) => {
+  if (typeof window === 'undefined') return
+  localStorage.setItem('categories', JSON.stringify(cats))
+}

--- a/models/Product.ts
+++ b/models/Product.ts
@@ -1,12 +1,6 @@
 import mongoose, { Schema, Document, Model } from 'mongoose'
 
-export enum Category {
-  Relleno = 'Relleno',
-  Masa = 'Masa',
-  Horneado = 'Horneado',
-  EnvasadoEtiquetado = 'Envasado y Etiquetado',
-  ManoDeObra = 'Mano de obra',
-}
+export type Category = string
 
 export enum UnitType {
   Kilo = 'kilo',
@@ -32,7 +26,7 @@ const ProductSchema = new Schema<IProduct>({
   },
   price: { type: Number, required: true },
   vat: { type: Number, required: true },
-  category: { type: String, enum: Object.values(Category) },
+  category: { type: String },
 })
 
 const Product =


### PR DESCRIPTION
## Summary
- allow arbitrary product categories in data model
- store categories in localStorage and show an input to add new ones
- display products grouped in accordion blocks
- load categories dynamically in edit modal

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aa141eabc8323afc96033bd9e169b