### PR TITLE
Add litro unit type

### DIFF
--- a/app/calculadora/page.tsx
+++ b/app/calculadora/page.tsx
@@ -35,7 +35,7 @@ const ORDERED_CATEGORIES: Category[] = [
   'Mano de obra',
 ]
 
-type UnitType = 'kilo' | 'envase' | 'unidad' | 'metro'
+type UnitType = 'kilo' | 'envase' | 'unidad' | 'metro' | 'litro'
 
 interface Product {
   name: string

--- a/app/productos/page.tsx
+++ b/app/productos/page.tsx
@@ -10,7 +10,7 @@ import {
 
 type Category = string
 
-type UnitType = 'kilo' | 'envase' | 'unidad' | 'metro'
+type UnitType = 'kilo' | 'envase' | 'unidad' | 'metro' | 'litro'
 
 interface Product {
   name: string
@@ -162,6 +162,7 @@ export default function ProductosPage() {
             <option value="envase">envase</option>
             <option value="unidad">unidad</option>
             <option value="metro">metro</option>
+            <option value="litro">litro</option>
           </select>
         </label>
         <label className="flex flex-col">

--- a/components/ProductEditModal.tsx
+++ b/components/ProductEditModal.tsx
@@ -5,7 +5,7 @@ import { getStoredCategories } from '../lib/categories'
 
 export type Category = string
 
-export type UnitType = 'kilo' | 'envase' | 'unidad' | 'metro'
+export type UnitType = 'kilo' | 'envase' | 'unidad' | 'metro' | 'litro'
 
 export interface Product {
   name: string
@@ -79,6 +79,7 @@ export default function ProductEditModal({ product, onClose, onSaved, categories
               <option value="envase">envase</option>
               <option value="unidad">unidad</option>
               <option value="metro">metro</option>
+              <option value="litro">litro</option>
             </select>
           </label>
           <label className="flex flex-col">

--- a/models/Product.ts
+++ b/models/Product.ts
@@ -7,6 +7,7 @@ export enum UnitType {
   Envase = 'envase',
   Unidad = 'unidad',
   Metro = 'metro',
+  Litro = 'litro',
 }
 
 export interface IProduct extends Document {


### PR DESCRIPTION
## Summary
- add `litro` to `UnitType` enum and related types
- expose `litro` as an option in product forms

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aa2cf43788323abd948fc5a93520c