### PR TITLE
Remove duplicate toast on startup

### DIFF
--- a/app/calculadora/page.tsx
+++ b/app/calculadora/page.tsx
@@ -166,9 +166,6 @@ export default function Home() {
         if (list.length > 0) {
           loadEmpanada(list[0])
           setName(list[0].name)
-          toast.info('Se cargó la primera empanada guardada', {
-            style: { background: '#16a34a', color: '#fff' },
-          })
         } else {
           toast.info('No hay empanadas guardadas. Usando valores por defecto', {
             style: { background: '#2563eb', color: '#fff' },


### PR DESCRIPTION
## Summary
- remove the toast shown when the first saved empanada is loaded

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aa8cfcce88323b43a950a4c9566c5