### PR TITLE
Update empanada list to show cost and profit

### DIFF
--- a/app/empanadas/page.tsx
+++ b/app/empanadas/page.tsx
@@ -3,9 +3,34 @@ import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { toast } from 'react-toastify'
 
+interface CostItem {
+  id: string
+  category: string
+  label: string
+  cost: number
+  vat: number
+}
+
 interface Empanada {
   name: string
+  costs: CostItem[]
+  margin: number
 }
+
+const getTotal = (costs: CostItem[]) =>
+  costs.reduce((sum, item) => sum + item.cost, 0)
+
+const getVatTotal = (costs: CostItem[]) =>
+  costs.reduce((sum, item) => sum + item.cost * item.vat / 100, 0)
+
+const getTotalWithVat = (costs: CostItem[]) => {
+  const total = getTotal(costs)
+  const vatTotal = getVatTotal(costs)
+  return total + vatTotal
+}
+
+const getProfit = (costs: CostItem[], margin: number) =>
+  getTotalWithVat(costs) * margin / 100
 
 export default function EmpanadasPage() {
   const [list, setList] = useState<Empanada[]>([])
@@ -43,22 +68,26 @@ export default function EmpanadasPage() {
     <div className="p-6 mt-6 max-w-md mx-auto bg-white rounded-lg shadow-lg">
       <h1 className="text-xl font-bold mb-4">Empanadas guardadas</h1>
       <ul className="divide-y">
-        {list.map(emp => (
-          <li key={emp.name} className="py-2 flex justify-between items-center">
-            <span
-              className="cursor-pointer text-blue-600 hover:underline"
-              onClick={() => openEmpanada(emp.name)}
-            >
-              {emp.name}
-            </span>
-            <button
-              className="text-red-600 ml-2 hover:underline"
-              onClick={() => deleteEmpanada(emp.name)}
-            >
-              Eliminar
-            </button>
-          </li>
-        ))}
+        {list.map(emp => {
+          const totalWithVat = getTotalWithVat(emp.costs)
+          const profit = getProfit(emp.costs, emp.margin)
+          return (
+            <li key={emp.name} className="py-2 flex justify-between items-center">
+              <span
+                className="cursor-pointer text-blue-600 hover:underline"
+                onClick={() => openEmpanada(emp.name)}
+              >
+                {emp.name} - Coste {totalWithVat.toFixed(2)} - Beneficio neto {profit.toFixed(2)}
+              </span>
+              <button
+                className="text-red-600 ml-2 hover:underline"
+                onClick={() => deleteEmpanada(emp.name)}
+              >
+                Eliminar
+              </button>
+            </li>
+          )
+        })}
         {list.length === 0 && <li>No hay empanadas guardadas</li>}
       </ul>
     </div>


### PR DESCRIPTION
## Summary
- expand Empanada interface with `costs` and `margin`
- add helpers to compute totals, VAT and profit
- display each empanada's cost with VAT and net profit in the list

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aac50441083239f064af6c4e22cf8