### PR TITLE
Add price and quantity to empanadas

### DIFF
--- a/__tests__/api/empanadas.test.ts
+++ b/__tests__/api/empanadas.test.ts
@@ -1,0 +1,65 @@
+import { GET, POST, DELETE } from '../../app/api/empanadas/route'
+import Empanada from '../../models/Empanada'
+import connectDB from '../../lib/mongoose'
+
+jest.mock('../../lib/mongoose')
+jest.mock('../../models/Empanada', () => ({
+  find: jest.fn(),
+  updateOne: jest.fn(),
+  deleteOne: jest.fn(),
+}))
+
+const mockedEmpanada = Empanada as jest.Mocked<typeof Empanada>
+
+describe('empanada API', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('GET returns list of empanadas', async () => {
+    mockedEmpanada.find.mockResolvedValue([{ name: 'Test', costs: [] }])
+    const res = await GET()
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(data).toEqual([{ name: 'Test', costs: [] }])
+  })
+
+  it('POST upserts empanada with quantity', async () => {
+    const payload = {
+      name: 'New',
+      costs: [
+        {
+          id: '1',
+          category: 'Masa',
+          label: 'Harina',
+          price: 1,
+          quantity: 2,
+          unitType: 'kilo',
+          cost: 2,
+          vat: 10,
+        },
+      ],
+      margin: 10,
+    }
+    const req = new Request('http://localhost/api/empanadas', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    })
+    const res = await POST(req)
+    expect(mockedEmpanada.updateOne).toHaveBeenCalledWith(
+      { name: payload.name },
+      { $set: payload },
+      { upsert: true }
+    )
+    expect(res.status).toBe(200)
+  })
+
+  it('DELETE removes empanada', async () => {
+    const req = new Request('http://localhost/api/empanadas?name=Del', {
+      method: 'DELETE',
+    })
+    const res = await DELETE(req)
+    expect(mockedEmpanada.deleteOne).toHaveBeenCalledWith({ name: 'Del' })
+    expect(res.status).toBe(200)
+  })
+})

--- a/app/api/empanadas/route.ts
+++ b/app/api/empanadas/route.ts
@@ -2,10 +2,15 @@ import { NextResponse } from 'next/server'
 import connectDB from '../../../lib/mongoose'
 import Empanada from '../../../models/Empanada'
 
+import { UnitType } from '../../../models/Product'
+
 interface CostItem {
   id: string
   category: string
   label: string
+  price: number
+  quantity: number
+  unitType?: UnitType
   cost: number
   vat: number
 }

--- a/app/calculadora/page.tsx
+++ b/app/calculadora/page.tsx
@@ -284,8 +284,9 @@ export default function Home() {
       id: c.id,
       category: c.category,
       label: c.label,
-      price: c.cost,
-      quantity: 1,
+      price: c.price ?? c.cost,
+      quantity: c.quantity ?? 1,
+      unitType: c.unitType ?? 'unidad',
       vat: c.vat,
     })))
     setMargin(emp.margin)

--- a/models/Empanada.ts
+++ b/models/Empanada.ts
@@ -1,9 +1,14 @@
 import mongoose, { Schema, Document, Model } from 'mongoose'
 
+import { UnitType } from './Product'
+
 interface CostItem {
   id: string
   category: string
   label: string
+  price: number
+  quantity: number
+  unitType?: UnitType
   cost: number
   vat: number
 }
@@ -19,6 +24,9 @@ const CostItemSchema = new Schema<CostItem>(
     id: String,
     category: String,
     label: String,
+    price: Number,
+    quantity: Number,
+    unitType: { type: String, enum: Object.values(UnitType), required: false },
     cost: Number,
     vat: Number,
   },


### PR DESCRIPTION
## Summary
- extend `CostItemSchema` with price, quantity and optional unitType
- accept these fields in empanada API route
- read saved price and quantity in calculator page
- unit tests for empanada API covering quantity handling

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aaddc7984832380bbebf1523f77ae