### PR TITLE
Fix duplicate category addition

### DIFF
--- a/__tests__/app/productos.test.tsx
+++ b/__tests__/app/productos.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import ProductosPage from '../../app/productos/page'
+import { toast } from 'react-toastify'
+
+jest.mock('next/navigation', () => ({
+  useSearchParams: () => ({ get: () => null }),
+  useRouter: () => ({ push: jest.fn() })
+}))
+
+jest.mock('react-toastify', () => ({
+  toast: {
+    success: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+  },
+  ToastContainer: () => null,
+}))
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  ;(global.fetch as any) = jest.fn(() =>
+    Promise.resolve({ json: () => Promise.resolve([]) })
+  )
+  localStorage.clear()
+})
+
+describe('ProductosPage category addition', () => {
+  it('prevents duplicate categories', async () => {
+    const user = userEvent.setup()
+    render(<ProductosPage />)
+    const input = screen.getAllByLabelText('Nombre')[0]
+    await user.type(input, 'Relleno')
+    const button = screen.getByRole('button', { name: 'Añadir' })
+    const select = screen.getByLabelText('Categoría') as HTMLSelectElement
+    const initialCount = select.options.length
+    await user.click(button)
+    expect(select.options.length).toBe(initialCount)
+    expect((toast.error as jest.Mock).mock.calls[0][0]).toBe('La categoría ya existe')
+  })
+})

--- a/app/productos/page.tsx
+++ b/app/productos/page.tsx
@@ -153,6 +153,12 @@ export default function ProductosPage() {
         <button
           onClick={() => {
             if (!newCategory) return
+            if (categories.includes(newCategory)) {
+              toast.error('La categoría ya existe', {
+                style: { background: '#dc2626', color: '#fff' },
+              })
+              return
+            }
             const cats = [...categories, newCategory]
             setCategories(cats)
             saveCategories(cats)


### PR DESCRIPTION
## Summary
- prevent adding an already existing category
- add regression test for duplicate category prevention

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ab5228aa883238ec51b604175cf0a