### PR TITLE
Allow partial export rows

### DIFF
--- a/app/calculadora/page.tsx
+++ b/app/calculadora/page.tsx
@@ -522,7 +522,7 @@ export default function Home() {
       </button>
       <button
         onClick={() => {
-          const rows = costs.map(c => ({
+          const rows: Record<string, any>[] = costs.map(c => ({
             Categoria: c.category,
             Concepto: c.label,
             Cantidad: c.quantity,

--- a/app/empanadas/page.tsx
+++ b/app/empanadas/page.tsx
@@ -79,7 +79,7 @@ export default function EmpanadasPage() {
           if (list.length === 0) return
           const wb = XLSX.utils.book_new()
           list.forEach((emp) => {
-            const rows = emp.costs.map((c) => ({
+            const rows: Record<string, any>[] = emp.costs.map((c) => ({
               Categoria: c.category,
               Concepto: c.label,
               Coste: c.cost,


### PR DESCRIPTION
## Summary
- loosen row typing in calculator export so blank rows work
- apply same typing for empanada list export

## Testing
- `npm run build` *(fails: next not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ab8c84bfc83239022b4feaaf91fda