### PR TITLE
Implement responsive nav

### DIFF
--- a/__tests__/components/Header.test.tsx
+++ b/__tests__/components/Header.test.tsx
@@ -1,14 +1,30 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import Header from '../../components/Header'
 
+const mockUsePathname = jest.fn()
+
 jest.mock('next/navigation', () => ({
-  usePathname: () => '/',
+  usePathname: () => mockUsePathname(),
   useRouter: () => ({ push: jest.fn() })
 }))
 
 describe('Header component', () => {
+  beforeEach(() => {
+    mockUsePathname.mockReturnValue('/calculadora')
+  })
+
   it('renders the site title', () => {
     render(<Header />)
     expect(screen.getByText('O pan de San Antonio')).toBeInTheDocument()
+  })
+
+  it('toggles the mobile navigation', () => {
+    render(<Header />)
+    const button = screen.getByRole('button', { name: /toggle navigation/i })
+    const mobileNav = screen.getByTestId('mobile-nav')
+
+    expect(mobileNav.className).toContain('hidden')
+    fireEvent.click(button)
+    expect(mobileNav.className).not.toContain('hidden')
   })
 })

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -7,6 +7,7 @@ export default function Header() {
   const pathname = usePathname()
   const router = useRouter()
   const inside = pathname !== '/'
+  const [menuOpen, setMenuOpen] = React.useState(false)
 
   const handleNav = (href: string, e: React.MouseEvent<HTMLAnchorElement>) => {
     if (pathname === '/calculadora' && (window as any).calculatorDirty) {
@@ -26,39 +27,81 @@ export default function Header() {
       <div className="container mx-auto flex justify-between items-center px-4">
         <h1 className="text-lg md:text-2xl font-bold">O pan de San Antonio</h1>
         {inside && (
-          <nav className="text-sm md:text-base">
-            <button onClick={logout} className="mr-4 hover:underline">Cerrar sesión</button>
-            <Link
-              href="/calculadora"
-              onClick={e => handleNav('/calculadora', e)}
-              className={`mr-4 hover:underline ${isActive('/calculadora') ? 'text-yellow-200 font-bold' : ''}`}
+          <>
+            <button
+              aria-label="Toggle navigation"
+              className="md:hidden"
+              onClick={() => setMenuOpen(prev => !prev)}
             >
-              Calculadora
-            </Link>
-            <Link
-              href="/empanadas"
-              onClick={e => handleNav('/empanadas', e)}
-              className={`mr-4 hover:underline ${isActive('/empanadas') ? 'text-yellow-200 font-bold' : ''}`}
-            >
-              Ver empanadas guardadas
-            </Link>
-            <Link
-              href="/productos"
-              onClick={e => handleNav('/productos', e)}
-              className={`mr-4 hover:underline ${isActive('/productos') ? 'text-yellow-200 font-bold' : ''}`}
-            >
-              Productos
-            </Link>
-            <Link
-              href="/registro"
-              onClick={e => handleNav('/registro', e)}
-              className={`hover:underline ${isActive('/registro') ? 'text-yellow-200 font-bold' : ''}`}
-            >
-              Registro
-            </Link>
-          </nav>
+              Menu
+            </button>
+            <nav data-testid="desktop-nav" className="hidden md:flex text-sm md:text-base">
+              <button onClick={logout} className="mr-4 hover:underline">Cerrar sesión</button>
+              <Link
+                href="/calculadora"
+                onClick={e => handleNav('/calculadora', e)}
+                className={`mr-4 hover:underline ${isActive('/calculadora') ? 'text-yellow-200 font-bold' : ''}`}
+              >
+                Calculadora
+              </Link>
+              <Link
+                href="/empanadas"
+                onClick={e => handleNav('/empanadas', e)}
+                className={`mr-4 hover:underline ${isActive('/empanadas') ? 'text-yellow-200 font-bold' : ''}`}
+              >
+                Ver empanadas guardadas
+              </Link>
+              <Link
+                href="/productos"
+                onClick={e => handleNav('/productos', e)}
+                className={`mr-4 hover:underline ${isActive('/productos') ? 'text-yellow-200 font-bold' : ''}`}
+              >
+                Productos
+              </Link>
+              <Link
+                href="/registro"
+                onClick={e => handleNav('/registro', e)}
+                className={`hover:underline ${isActive('/registro') ? 'text-yellow-200 font-bold' : ''}`}
+              >
+                Registro
+              </Link>
+            </nav>
+          </>
         )}
       </div>
+      {inside && (
+        <nav data-testid="mobile-nav" className={`${menuOpen ? 'block' : 'hidden'} md:hidden px-4 text-sm mt-2`}>
+          <button onClick={logout} className="block mb-2 hover:underline">Cerrar sesión</button>
+          <Link
+            href="/calculadora"
+            onClick={e => handleNav('/calculadora', e)}
+            className={`block mb-2 hover:underline ${isActive('/calculadora') ? 'text-yellow-200 font-bold' : ''}`}
+          >
+            Calculadora
+          </Link>
+          <Link
+            href="/empanadas"
+            onClick={e => handleNav('/empanadas', e)}
+            className={`block mb-2 hover:underline ${isActive('/empanadas') ? 'text-yellow-200 font-bold' : ''}`}
+          >
+            Ver empanadas guardadas
+          </Link>
+          <Link
+            href="/productos"
+            onClick={e => handleNav('/productos', e)}
+            className={`block mb-2 hover:underline ${isActive('/productos') ? 'text-yellow-200 font-bold' : ''}`}
+          >
+            Productos
+          </Link>
+          <Link
+            href="/registro"
+            onClick={e => handleNav('/registro', e)}
+            className={`block hover:underline ${isActive('/registro') ? 'text-yellow-200 font-bold' : ''}`}
+          >
+            Registro
+          </Link>
+        </nav>
+      )}
     </header>
   )
 }


### PR DESCRIPTION
## Summary
- add mobile menu state and toggle button
- show vertical dropdown menu on small screens
- keep horizontal menu on larger screens
- add tests for responsive nav toggle

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ad3077aa08323becfc1d96d2f1bdf