### PR TITLE
Fix VAT propagation

### DIFF
--- a/app/calculadora/page.tsx
+++ b/app/calculadora/page.tsx
@@ -198,7 +198,12 @@ export default function Home() {
       current.map(item => {
         const prod = products.find(p => p.name === item.label)
         if (prod) {
-          return { ...item, price: prod.price, unitType: prod.unitType }
+          return {
+            ...item,
+            price: prod.price,
+            unitType: prod.unitType,
+            vat: prod.vat,
+          }
         }
         return item
       })


### PR DESCRIPTION
## Summary
- propagate VAT field in calculator when products are updated

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ad7e2b1ac8323875acfb82d640ae8