### PR TITLE
Add Excel import for empanadas

### DIFF
--- a/lib/importExcel.ts
+++ b/lib/importExcel.ts
@@ -1,0 +1,44 @@
+import * as XLSX from 'xlsx'
+
+export interface ImportedCost {
+  category: string
+  label: string
+  price: number
+  quantity: number
+  unitType: string
+  vat: number
+}
+
+export interface ImportedEmpanada {
+  name: string
+  costs: ImportedCost[]
+  margin: number
+}
+
+export async function readEmpanadaFile(file: File): Promise<ImportedEmpanada> {
+  const data = await file.arrayBuffer()
+  const wb = XLSX.read(data)
+  const sheetName = wb.SheetNames[0]
+  const ws = wb.Sheets[sheetName]
+  const rows: Record<string, any>[] = XLSX.utils.sheet_to_json(ws)
+  const costs: ImportedCost[] = []
+  let margin = 0
+
+  rows.forEach(row => {
+    if (row['Concepto'] === 'Margen (%)') {
+      margin = parseFloat(row['Coste']) || 0
+    } else if (row['Categoria']) {
+      costs.push({
+        category: row['Categoria'],
+        label: row['Concepto'],
+        quantity: parseFloat(row['Cantidad'] ?? '0'),
+        unitType: row['Medida'],
+        price: parseFloat(row['Precio'] ?? '0'),
+        vat: parseFloat(row['IVA'] ?? '0'),
+      })
+    }
+  })
+
+  return { name: sheetName, costs, margin }
+}
+


### PR DESCRIPTION
## Summary
- allow loading empanada data from an exported Excel file
- parse workbook with `readEmpanadaFile`
- add button and hidden input to upload Excel on calculator page

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684adc8ae9b08323ba80cecf7755249e