### PR TITLE
type: fix

### DIFF
--- a/app/calculadora/page.tsx
+++ b/app/calculadora/page.tsx
@@ -52,7 +52,7 @@ interface NewEntry {
   quantity: number
 }
 
-const initialCosts = [
+const initialCosts: CostItem[] = [
   { id: 'carne', category: 'Relleno', label: 'Carne', price: 1.95, quantity: 1, vat: 10, unitType: 'kilo' },
   { id: 'cebolla', category: 'Relleno', label: 'Cebolla', price: 0.8, quantity: 1, vat: 10, unitType: 'kilo' },
   { id: 'azafran', category: 'Relleno', label: 'Azafrán', price: 0.025, quantity: 1, vat: 10, unitType: 'kilo' },


### PR DESCRIPTION
## Summary
- fix TypeScript type error by explicitly typing `initialCosts` as `CostItem[]`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ae454f2148323843fe0e058aa3feb