### PR TITLE
Unify CostItem type

### DIFF
--- a/app/api/empanadas/route.ts
+++ b/app/api/empanadas/route.ts
@@ -2,18 +2,7 @@ import { NextResponse } from 'next/server'
 import connectDB from '../../../lib/mongoose'
 import Empanada from '../../../models/Empanada'
 
-import { UnitType } from '../../../models/Product'
-
-interface CostItem {
-  id: string
-  category: string
-  label: string
-  price: number
-  quantity: number
-  unitType?: UnitType
-  cost: number
-  vat: number
-}
+import { UnitType, CostItem } from '../../../types'
 
 interface EmpanadaPayload {
   name: string

--- a/app/calculadora/page.tsx
+++ b/app/calculadora/page.tsx
@@ -8,16 +8,7 @@ import { readEmpanadaFile } from '../../lib/importExcel'
 import ProductEditModal from '../../components/ProductEditModal'
 import { useSearchParams, useRouter } from 'next/navigation'
 import { toast } from 'react-toastify'
-
-interface CostItem {
-  id: string
-  category: string
-  label: string
-  price: number
-  quantity: number
-  vat: number
-  unitType: UnitType
-}
+import { CostItem, UnitType } from '../../types'
 
 interface Empanada {
   name: string
@@ -39,8 +30,6 @@ const ORDERED_CATEGORIES: Category[] = [
   'Envasado y Etiquetado',
   'Mano de obra',
 ]
-
-type UnitType = 'kilo' | 'envase' | 'unidad' | 'metro' | 'litro'
 
 interface Product {
   name: string

--- a/app/empanadas/page.tsx
+++ b/app/empanadas/page.tsx
@@ -4,14 +4,7 @@ import { downloadWorkbook } from '../../lib/exportExcel'
 import * as XLSX from 'xlsx'
 import { useRouter } from 'next/navigation'
 import { toast } from 'react-toastify'
-
-interface CostItem {
-  id: string
-  category: string
-  label: string
-  cost: number
-  vat: number
-}
+import { CostItem } from '../../types'
 
 interface Empanada {
   name: string

--- a/app/productos/page.tsx
+++ b/app/productos/page.tsx
@@ -11,10 +11,9 @@ import {
   getStoredCategories,
   saveCategories,
 } from '../../lib/categories'
+import { UnitType } from '../../types'
 
 type Category = string
-
-type UnitType = 'kilo' | 'envase' | 'unidad' | 'metro' | 'litro'
 
 interface Product {
   name: string

--- a/components/ProductEditModal.tsx
+++ b/components/ProductEditModal.tsx
@@ -2,10 +2,9 @@
 import { useState, useEffect } from 'react'
 import { toast } from 'react-toastify'
 import { getStoredCategories } from '../lib/categories'
+import { UnitType } from '../types'
 
 export type Category = string
-
-export type UnitType = 'kilo' | 'envase' | 'unidad' | 'metro' | 'litro'
 
 export interface Product {
   name: string

--- a/models/Empanada.ts
+++ b/models/Empanada.ts
@@ -1,17 +1,7 @@
 import mongoose, { Schema, Document, Model } from 'mongoose'
 
 import { UnitType } from './Product'
-
-interface CostItem {
-  id: string
-  category: string
-  label: string
-  price: number
-  quantity: number
-  unitType?: UnitType
-  cost: number
-  vat: number
-}
+import { CostItem } from '../types'
 
 export interface IEmpanada extends Document {
   name: string

--- a/types.ts
+++ b/types.ts
@@ -1,0 +1,12 @@
+export type UnitType = 'kilo' | 'envase' | 'unidad' | 'metro' | 'litro'
+
+export interface CostItem {
+  id: string
+  category: string
+  label: string
+  price: number
+  quantity: number
+  unitType?: UnitType
+  vat: number
+  cost?: number
+}


### PR DESCRIPTION
## Summary
- add shared `CostItem` interface
- use the shared type across pages, API and model

## Testing
- `npm test` *(fails: jest not found)*
- `npx tsc -p tsconfig.json` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684aeb69e9c083238fe14f6b232b5bf7