### PR TITLE
Configure local Tailwind

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,9 +6,7 @@ import ToastProvider from '../components/ToastProvider'
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="es">
-      <head>
-        <script src="https://cdn.tailwindcss.com"></script>
-      </head>
+      <head />
       <body className="bg-gradient-to-br from-green-50 to-green-100 text-gray-900 flex flex-col min-h-screen">
         <Header />
         <ToastProvider />

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,3 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 body {
   margin: 0;
   padding: 0;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,8 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ['./app/**/*.{ts,tsx}', './components/**/*.{ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- configure Tailwind as a local PostCSS plugin
- include Tailwind directives in global styles
- remove CDN script

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684af1dd586483239c030140db72a557